### PR TITLE
Fix for strict mode

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -7,7 +7,6 @@ var cacheSize = 0;
 
 function setLimit(limit) {
     if (limit == cacheSize) return;
-    delete lru;
     cacheSize = limit;
     if (limit > 0) lru = new LRUCache({ "maxSize": limit });
     else lru = null;


### PR DESCRIPTION
This pull request aim to make rousseau strict mode compatible.
### Strict mode

Couldn't delete local variable in strict mode.

> strict mode forbids deleting plain names. delete name in strict mode is a syntax error:
> -- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#Converting_mistakes_into_errors
- [Understanding delete — Perfection Kills](http://perfectionkills.com/understanding-delete/)
- [Strict mode - JavaScript | MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#Converting_mistakes_into_errors)
### Use case

webpack2? force modules to use strict mode.
I tried to bundle roussea by webpack and occur following error:

```
rousseau/lib/cache.js Deleting local variable in strict mode (10:4)
You may need an appropriate loader to handle this file type.
| function setLimit(limit) {
|     if (limit == cacheSize) return;
|     delete lru;
| 
|     cacheSize = limit;
 @ ./~/rousseau/lib/index.js 5:12-30
```
- [webpack2: Module parse failed -> 'with' in strict mode · Issue #1939 · webpack/webpack](https://github.com/webpack/webpack/issues/1939)
- [Webpack 2 support ? · Issue #196 · ampedandwired/html-webpack-plugin](https://github.com/ampedandwired/html-webpack-plugin/issues/196)

I'v deleted `delete lru;`, because it throw error in strict mode.
